### PR TITLE
Add DocManager __version__

### DIFF
--- a/mongo_connector/doc_managers/solr_doc_manager.py
+++ b/mongo_connector/doc_managers/solr_doc_manager.py
@@ -37,6 +37,10 @@ from mongo_connector.util import exception_wrapper, retry_until_ok
 from mongo_connector.doc_managers.doc_manager_base import DocManagerBase
 from mongo_connector.doc_managers.formatters import DocumentFlattener
 
+__version__ = '0.1.0'
+"""Solr DocManager version."""
+
+
 wrap_exceptions = exception_wrapper({
     SolrError: errors.OperationFailed,
     URLError: errors.ConnectionFailed,


### PR DESCRIPTION
mongo-connector 2.5.0 will log the `__version__` at startup. Introduced here: https://github.com/mongodb-labs/mongo-connector/pull/575