### PR TITLE
Update mongo-connector dependency to 2.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(name='solr-doc-manager',
       author='MongoDB, Inc.',
       author_email='mongodb-user@googlegroups.com',
       url='https://github.com/mongodb-labs/solr-doc-manager',
-      install_requires=['mongo-connector >= 2.3.0', "pysolr >= 3.1.0"],
+      install_requires=['mongo-connector >= 2.5.0', "pysolr >= 3.1.0"],
       packages=["mongo_connector", "mongo_connector.doc_managers"],
       license="Apache License, Version 2.0",
       classifiers=[


### PR DESCRIPTION
Before mongo-connector 2.5.0 the solr-doc-manager was packaged with mongo-connector itself.