### PR TITLE
Added handling for datetime.datetime to JSON serialization exception

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Version 0.1.1
+-------------
+
+Added handling for datetime.datetime to JSON serialization exception in pysolr (starting with v3.9.0)
+
+
 Version 0.1.0
 -------------
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ except IOError:
     long_description = None  # Install without README.rst
 
 setup(name='solr-doc-manager',
-      version='0.1.0',
+      version='0.1.1',
       description='Solr plugin for mongo-connector',
       long_description=long_description,
       platforms=['any'],


### PR DESCRIPTION
Handles issues related to pysolr: pysolr starting from v3.9.0 (3.8.1 works fine) will throw the following exceptions:
- TypeError: Object of type 'datetime' is not JSON serializable
- TypeError: datetime.datetime(2012, 8, 8, 21, 46, 24, 862000) is not JSON serializable