### PR TITLE
Does not update document changes for mongdb 5.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /dist
 /build
 /.*
+/solr_doc_manager.egg-info

--- a/mongo_connector/doc_managers/solr_doc_manager.py
+++ b/mongo_connector/doc_managers/solr_doc_manager.py
@@ -37,7 +37,7 @@ from mongo_connector.util import exception_wrapper, retry_until_ok
 from mongo_connector.doc_managers.doc_manager_base import DocManagerBase
 from mongo_connector.doc_managers.formatters import DocumentFlattener
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 """Solr DocManager version."""
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ except IOError:
     long_description = None  # Install without README.rst
 
 setup(name='solr-doc-manager',
-      version='0.1.0',
+      version='0.1.1',
       description='Solr plugin for mongo-connector',
       long_description=long_description,
       platforms=['any'],


### PR DESCRIPTION
Current version of solr-doc-manager has issue with mongo db 5.x version because oplog entry format has changed.  You can find detail in my [comment](https://github.com/yougov/mongo-connector/issues/933#issuecomment-1241019812). It will be useful for community if my changes can be reviewed and released.